### PR TITLE
Space behavior QoL updates for Han shape-based layout

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use_flake

--- a/app/src/main/kotlin/dev/patrickgold/florisboard/ime/editor/EditorInstance.kt
+++ b/app/src/main/kotlin/dev/patrickgold/florisboard/ime/editor/EditorInstance.kt
@@ -509,8 +509,7 @@ class EditorInstance(context: Context) : AbstractEditorInstance(context) {
          if (!(isActive || forceActive) || selection.isNotValid || selection.start <= 0 || text.isEmpty()) return false
          val textBefore = content.getTextBeforeCursor(1)
          val punctuationRule = nlpManager.getActivePunctuationRule()
-        // TODO: maybe put this recurring condition in a function that determines CJK
-         if (subtypeManager.activeSubtype.primaryLocale.language.startsWith("zh")) return false;
+         if (subtypeManager.activeSubtype.primaryLocale.isLocaleCJK()) return false;
          return textBefore.isNotEmpty() &&
              (punctuationRule.symbolsPrecedingPhantomSpace.contains(textBefore[textBefore.length - 1]) ||
                  textBefore[textBefore.length - 1].isLetterOrDigit()) &&

--- a/app/src/main/kotlin/dev/patrickgold/florisboard/ime/editor/EditorInstance.kt
+++ b/app/src/main/kotlin/dev/patrickgold/florisboard/ime/editor/EditorInstance.kt
@@ -41,6 +41,7 @@ import dev.patrickgold.florisboard.lib.android.AndroidVersion
 import dev.patrickgold.florisboard.lib.android.showShortToast
 import dev.patrickgold.florisboard.lib.ext.ExtensionComponentName
 import dev.patrickgold.florisboard.nlpManager
+import dev.patrickgold.florisboard.subtypeManager
 import kotlinx.coroutines.runBlocking
 import java.util.concurrent.atomic.AtomicInteger
 
@@ -53,6 +54,7 @@ class EditorInstance(context: Context) : AbstractEditorInstance(context) {
     private val appContext by context.appContext()
     private val clipboardManager by context.clipboardManager()
     private val keyboardManager by context.keyboardManager()
+    private val subtypeManager by context.subtypeManager()
     private val nlpManager by context.nlpManager()
 
     private val activeState get() = keyboardManager.activeState
@@ -502,17 +504,17 @@ class EditorInstance(context: Context) : AbstractEditorInstance(context) {
     }
 
     private fun PhantomSpaceState.determine(text: String, forceActive: Boolean = false): Boolean {
-        // TODO: Properly handle not adding a space when commiting suggestions in CJK subtypes
-        return false;
-        // val content = activeContent
-        // val selection = content.selection
-        // if (!(isActive || forceActive) || selection.isNotValid || selection.start <= 0 || text.isEmpty()) return false
-        // val textBefore = content.getTextBeforeCursor(1)
-        // val punctuationRule = nlpManager.getActivePunctuationRule()
-        // return textBefore.isNotEmpty() &&
-        //     (punctuationRule.symbolsPrecedingPhantomSpace.contains(textBefore[textBefore.length - 1]) ||
-        //         textBefore[textBefore.length - 1].isLetterOrDigit()) &&
-        //     (punctuationRule.symbolsFollowingPhantomSpace.contains(text[0]) || text[0].isLetterOrDigit())
+         val content = activeContent
+         val selection = content.selection
+         if (!(isActive || forceActive) || selection.isNotValid || selection.start <= 0 || text.isEmpty()) return false
+         val textBefore = content.getTextBeforeCursor(1)
+         val punctuationRule = nlpManager.getActivePunctuationRule()
+        // TODO: maybe put this recurring condition in a function that determines CJK
+         if (subtypeManager.activeSubtype.primaryLocale.language.startsWith("zh")) return false;
+         return textBefore.isNotEmpty() &&
+             (punctuationRule.symbolsPrecedingPhantomSpace.contains(textBefore[textBefore.length - 1]) ||
+                 textBefore[textBefore.length - 1].isLetterOrDigit()) &&
+             (punctuationRule.symbolsFollowingPhantomSpace.contains(text[0]) || text[0].isLetterOrDigit())
     }
 
     class AutoSpaceState {

--- a/app/src/main/kotlin/dev/patrickgold/florisboard/ime/editor/EditorInstance.kt
+++ b/app/src/main/kotlin/dev/patrickgold/florisboard/ime/editor/EditorInstance.kt
@@ -509,7 +509,7 @@ class EditorInstance(context: Context) : AbstractEditorInstance(context) {
          if (!(isActive || forceActive) || selection.isNotValid || selection.start <= 0 || text.isEmpty()) return false
          val textBefore = content.getTextBeforeCursor(1)
          val punctuationRule = nlpManager.getActivePunctuationRule()
-         if (subtypeManager.activeSubtype.primaryLocale.isLocaleCJK()) return false;
+         if (subtypeManager.activeSubtype.primaryLocale.supportsAutoSpace) return false;
          return textBefore.isNotEmpty() &&
              (punctuationRule.symbolsPrecedingPhantomSpace.contains(textBefore[textBefore.length - 1]) ||
                  textBefore[textBefore.length - 1].isLetterOrDigit()) &&

--- a/app/src/main/kotlin/dev/patrickgold/florisboard/ime/editor/EditorInstance.kt
+++ b/app/src/main/kotlin/dev/patrickgold/florisboard/ime/editor/EditorInstance.kt
@@ -509,7 +509,7 @@ class EditorInstance(context: Context) : AbstractEditorInstance(context) {
          if (!(isActive || forceActive) || selection.isNotValid || selection.start <= 0 || text.isEmpty()) return false
          val textBefore = content.getTextBeforeCursor(1)
          val punctuationRule = nlpManager.getActivePunctuationRule()
-         if (subtypeManager.activeSubtype.primaryLocale.supportsAutoSpace) return false;
+         if (!subtypeManager.activeSubtype.primaryLocale.supportsAutoSpace) return false;
          return textBefore.isNotEmpty() &&
              (punctuationRule.symbolsPrecedingPhantomSpace.contains(textBefore[textBefore.length - 1]) ||
                  textBefore[textBefore.length - 1].isLetterOrDigit()) &&

--- a/app/src/main/kotlin/dev/patrickgold/florisboard/ime/keyboard/KeyboardManager.kt
+++ b/app/src/main/kotlin/dev/patrickgold/florisboard/ime/keyboard/KeyboardManager.kt
@@ -550,7 +550,6 @@ class KeyboardManager(context: Context) : InputKeyEventReceiver {
                 }
             }
         }
-        // TODO: maybe put this recurring condition in a function that determines CJK
         if (subtypeManager.activeSubtype.primaryLocale.supportsAutoSpace &&
                 candidate != null) { /* Do nothing */ } else {
             editorInstance.commitText(KeyCode.SPACE.toChar().toString())

--- a/app/src/main/kotlin/dev/patrickgold/florisboard/ime/keyboard/KeyboardManager.kt
+++ b/app/src/main/kotlin/dev/patrickgold/florisboard/ime/keyboard/KeyboardManager.kt
@@ -551,7 +551,7 @@ class KeyboardManager(context: Context) : InputKeyEventReceiver {
             }
         }
         // TODO: maybe put this recurring condition in a function that determines CJK
-        if (subtypeManager.activeSubtype.primaryLocale.isLocaleCJK() &&
+        if (subtypeManager.activeSubtype.primaryLocale.supportsAutoSpace &&
                 candidate != null) { /* Do nothing */ } else {
             editorInstance.commitText(KeyCode.SPACE.toChar().toString())
         }

--- a/app/src/main/kotlin/dev/patrickgold/florisboard/ime/keyboard/KeyboardManager.kt
+++ b/app/src/main/kotlin/dev/patrickgold/florisboard/ime/keyboard/KeyboardManager.kt
@@ -550,7 +550,7 @@ class KeyboardManager(context: Context) : InputKeyEventReceiver {
                 }
             }
         }
-        if (subtypeManager.activeSubtype.primaryLocale.supportsAutoSpace &&
+        if (!subtypeManager.activeSubtype.primaryLocale.supportsAutoSpace &&
                 candidate != null) { /* Do nothing */ } else {
             editorInstance.commitText(KeyCode.SPACE.toChar().toString())
         }

--- a/app/src/main/kotlin/dev/patrickgold/florisboard/ime/keyboard/KeyboardManager.kt
+++ b/app/src/main/kotlin/dev/patrickgold/florisboard/ime/keyboard/KeyboardManager.kt
@@ -551,7 +551,7 @@ class KeyboardManager(context: Context) : InputKeyEventReceiver {
             }
         }
         // TODO: maybe put this recurring condition in a function that determines CJK
-        if (subtypeManager.activeSubtype.primaryLocale.language.startsWith("zh") &&
+        if (subtypeManager.activeSubtype.primaryLocale.isLocaleCJK() &&
                 candidate != null) { /* Do nothing */ } else {
             editorInstance.commitText(KeyCode.SPACE.toChar().toString())
         }

--- a/app/src/main/kotlin/dev/patrickgold/florisboard/ime/keyboard/KeyboardManager.kt
+++ b/app/src/main/kotlin/dev/patrickgold/florisboard/ime/keyboard/KeyboardManager.kt
@@ -528,7 +528,8 @@ class KeyboardManager(context: Context) : InputKeyEventReceiver {
      * enabled by the user.
      */
     private fun handleSpace(data: KeyData) {
-        nlpManager.getAutoCommitCandidate()?.let { commitCandidate(it) }
+        val candidate = nlpManager.getAutoCommitCandidate()
+        candidate?.let { commitCandidate(it) }
         if (prefs.keyboard.spaceBarSwitchesToCharacters.get()) {
             when (activeState.keyboardMode) {
                 KeyboardMode.NUMERIC_ADVANCED,
@@ -549,8 +550,11 @@ class KeyboardManager(context: Context) : InputKeyEventReceiver {
                 }
             }
         }
-        // TODO: Properly handle not adding a space when commiting suggestions in CJK subtypes
-        // editorInstance.commitText(KeyCode.SPACE.toChar().toString())
+        // TODO: maybe put this recurring condition in a function that determines CJK
+        if (subtypeManager.activeSubtype.primaryLocale.language.startsWith("zh") &&
+                candidate != null) { /* Do nothing */ } else {
+            editorInstance.commitText(KeyCode.SPACE.toChar().toString())
+        }
     }
 
     /**

--- a/app/src/main/kotlin/dev/patrickgold/florisboard/lib/FlorisLocale.kt
+++ b/app/src/main/kotlin/dev/patrickgold/florisboard/lib/FlorisLocale.kt
@@ -278,6 +278,8 @@ class FlorisLocale private constructor(val base: Locale) {
         }
     }
 
+    fun isLocaleCJK(): Boolean = this.language.startsWith("zh")
+
     /**
      * Generate a debug string representing this locale. Not to be confused
      * with [java.util.Locale.toString], which produces a locale tag. If such

--- a/app/src/main/kotlin/dev/patrickgold/florisboard/lib/FlorisLocale.kt
+++ b/app/src/main/kotlin/dev/patrickgold/florisboard/lib/FlorisLocale.kt
@@ -196,6 +196,16 @@ class FlorisLocale private constructor(val base: Locale) {
         }
 
     /**
+     * Returns true if suggestions in this language should have spaces added after, false otherwise.
+     * TODO: this is absolutely not exhaustive and hard-coded, find solution based on ICU or system
+     */
+    val supportsAutoSpace: Boolean
+        get() = when (language) {
+            "zh", "ko", "jp", "th" -> false
+            else -> true
+        }
+
+    /**
      * Generates the language tag for this locale in the format `xx`,
      * `xx-YY` or `xx-YY-zzz` and returns it as a string.
      *
@@ -277,8 +287,6 @@ class FlorisLocale private constructor(val base: Locale) {
             append(']')
         }
     }
-
-    fun isLocaleCJK(): Boolean = this.language.startsWith("zh")
 
     /**
      * Generate a debug string representing this locale. Not to be confused

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,84 @@
+{
+  description = "florisboard build environment";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs";
+    flake-utils = {
+      url = "github:numtide/flake-utils";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+  };
+
+  outputs = {
+    self,
+    nixpkgs,
+    flake-utils,
+  }: let
+    supportedSystems = with flake-utils.lib.system; [x86_64-linux x86_64-darwin aarch64-darwin];
+    forAllSystems = f: nixpkgs.lib.genAttrs supportedSystems (system: f system);
+    android = {
+      versions = {
+        tools = "26.1.1";
+        platformTools = "33.0.2";
+        buildTools = "31.0.0";
+        ndk = "22.1.7171670";
+        cmake = "3.22.1";
+        emulator = "31.3.9";
+      };
+      platforms = ["24" "25" "26" "27" "28" "29" "30" "31" "32"];
+    };
+  in
+    flake-utils.lib.eachSystem supportedSystems
+    (
+      system: let
+        pkgs = import nixpkgs {
+          inherit system;
+          config = {
+            android_sdk.accept_license = true; # accept all of the sdk licenses
+            allowUnfree = true; # needed to get android stuff to compile
+          };
+        };
+        # Make the android enviornment we specify
+        android-composition = pkgs.androidenv.composeAndroidPackages {
+          toolsVersion = android.versions.tools;
+          platformToolsVersion = android.versions.platformTools;
+          buildToolsVersions = [android.versions.buildTools];
+          platformVersions = android.platforms;
+          cmakeVersions = [android.versions.cmake];
+          includeNDK = true;
+          ndkVersions = [android.versions.ndk];
+          includeEmulator = true;
+          emulatorVersion = android.versions.emulator;
+        };
+        android-sdk =
+          (pkgs.androidenv.composeAndroidPackages {
+            toolsVersion = android.versions.tools;
+            platformToolsVersion = android.versions.platformTools;
+            buildToolsVersions = [android.versions.buildTools];
+            platformVersions = android.platforms;
+            cmakeVersions = [android.versions.cmake];
+            includeNDK = true;
+            ndkVersions = [android.versions.ndk];
+          })
+          .androidsdk;
+      in rec {
+        devShells.default = pkgs.mkShell rec {
+          ANDROID_SDK_ROOT = "${android-sdk}/libexec/android-sdk";
+          ANDROID_NDK_ROOT = "${ANDROID_SDK_ROOT}/ndk-bundle";
+          GRADLE_OPTS = "-Dorg.gradle.project.android.aapt2FromMavenOverride=${ANDROID_SDK_ROOT}/build-tools/${android.versions.buildTools}/aapt2";
+          JAVA_HOME = "${pkgs.jdk8.home}";
+          nativeBulidInputs = with pkgs; [
+            android-sdk
+            jdk8
+            clang
+            kotlin-language-server
+          ];
+
+          # Use the same cmakeVersion here
+          shellHook = ''
+            export PATH="$(echo "$ANDROID_SDK_ROOT/cmake/${android.versions.cmake}".*/bin):$PATH"
+          '';
+        };
+      }
+    );
+}


### PR DESCRIPTION
Separate the space behavior of the new nlp providers and the regular Latin ones, and expose setting nlp providers to the subtype editor. These allow Latin layouts and the new layout to coexist.

TODO: switching subtypes with different nlp providers currently does not reset suggestions, so you would still have suggestions from another language until you type or move your cursor.