### PR TITLE
Mixed language input QoL updates

### DIFF
--- a/app/src/main/assets/ime/keyboard/org.florisboard.layouts/layouts/symbolsMod/cjk.json
+++ b/app/src/main/assets/ime/keyboard/org.florisboard.layouts/layouts/symbolsMod/cjk.json
@@ -8,7 +8,7 @@
     { "code": -201, "label": "view_characters", "type": "system_gui" },
     { "$": "char_width_selector",
       "full": { "code": 12289, "label": "、", "popup": {
-          "main": { "code":   44, "label": "," }
+          "main": { "code": 65292, "label": "，" }
         }
       },
       "half": { "code": 65380, "label": "､", "popup": {

--- a/app/src/main/kotlin/dev/patrickgold/florisboard/FlorisImeService.kt
+++ b/app/src/main/kotlin/dev/patrickgold/florisboard/FlorisImeService.kt
@@ -25,6 +25,7 @@ import android.os.Bundle
 import android.util.Size
 import android.util.TypedValue
 import android.view.Gravity
+import android.view.KeyEvent
 import android.view.View
 import android.view.ViewGroup
 import android.view.WindowManager
@@ -619,6 +620,11 @@ class FlorisImeService : LifecycleInputMethodService() {
             DevtoolsOverlay(modifier = Modifier.fillMaxSize())
         }
     }
+
+    override fun onKeyDown(keyCode: Int, event: KeyEvent?): Boolean =
+        if (keyboardManager.onHardwareKeyDown(keyCode, event)) true
+        else super.onKeyDown(keyCode, event)
+
 
     private inner class ComposeInputView : AbstractComposeView(this) {
         init {

--- a/app/src/main/kotlin/dev/patrickgold/florisboard/ime/editor/AbstractEditorInstance.kt
+++ b/app/src/main/kotlin/dev/patrickgold/florisboard/ime/editor/AbstractEditorInstance.kt
@@ -31,6 +31,7 @@ import dev.patrickgold.florisboard.ime.text.composing.Composer
 import dev.patrickgold.florisboard.keyboardManager
 import dev.patrickgold.florisboard.lib.ext.ExtensionComponentName
 import dev.patrickgold.florisboard.lib.kotlin.guardedByLock
+import dev.patrickgold.florisboard.nlpManager
 import dev.patrickgold.florisboard.subtypeManager
 import kotlinx.coroutines.MainScope
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -53,6 +54,7 @@ abstract class AbstractEditorInstance(context: Context) {
 
     private val keyboardManager by context.keyboardManager()
     private val subtypeManager by context.subtypeManager()
+    private val nlpManager by context.nlpManager()
     private val scope = MainScope()
     protected val breakIterators = BreakIteratorGroup()
 
@@ -235,7 +237,7 @@ abstract class AbstractEditorInstance(context: Context) {
                 EditorRange.Unspecified
             }
         val localComposing = if (referencePrevComposing != null) {
-            // when old composing is passed on, use old composing.start; 
+            // when old composing is passed on, use old composing.start;
             // unless it's invalid (expecting a (-1, -1) composing), then use invalid composing
             if (referencePrevComposing.isValid) EditorRange(referencePrevComposing.start, localCurrentWord.end)
             else referencePrevComposing
@@ -287,17 +289,7 @@ abstract class AbstractEditorInstance(context: Context) {
     }
 
     private suspend fun determineLocalComposing(textBeforeSelection: CharSequence): EditorRange {
-        return breakIterators.word(subtypeManager.activeSubtype.primaryLocale) {
-            it.setText(textBeforeSelection.toString())
-            val end = it.last()
-            val isWord = it.ruleStatus != BreakIterator.WORD_NONE
-            if (isWord) {
-                val start = it.previous()
-                EditorRange(start, end)
-            } else {
-                EditorRange.Unspecified
-            }
-        }
+        return nlpManager.determineLocalComposing(textBeforeSelection, breakIterators)
     }
 
     private fun InputConnection.setComposingRegion(composing: EditorRange) {

--- a/app/src/main/kotlin/dev/patrickgold/florisboard/ime/editor/AbstractEditorInstance.kt
+++ b/app/src/main/kotlin/dev/patrickgold/florisboard/ime/editor/AbstractEditorInstance.kt
@@ -411,8 +411,7 @@ abstract class AbstractEditorInstance(context: Context) {
             val newContent = content.generateCopy(
                 selection = newSelection,
                 textBeforeSelection = buildString {
-                    append(content.textBeforeSelection)
-                    removeSuffix(content.composingText)
+                    append(content.textBeforeSelection.removeSuffix(content.composingText))
                     append(text)
                 },
                 selectedText = "",

--- a/app/src/main/kotlin/dev/patrickgold/florisboard/ime/editor/EditorInstance.kt
+++ b/app/src/main/kotlin/dev/patrickgold/florisboard/ime/editor/EditorInstance.kt
@@ -41,6 +41,7 @@ import dev.patrickgold.florisboard.lib.android.AndroidVersion
 import dev.patrickgold.florisboard.lib.android.showShortToast
 import dev.patrickgold.florisboard.lib.ext.ExtensionComponentName
 import dev.patrickgold.florisboard.nlpManager
+import dev.patrickgold.florisboard.subtypeManager
 import kotlinx.coroutines.runBlocking
 import java.util.concurrent.atomic.AtomicInteger
 
@@ -54,6 +55,7 @@ class EditorInstance(context: Context) : AbstractEditorInstance(context) {
     private val clipboardManager by context.clipboardManager()
     private val keyboardManager by context.keyboardManager()
     private val nlpManager by context.nlpManager()
+    private val subtypeManager by context.subtypeManager()
 
     private val activeState get() = keyboardManager.activeState
     val autoSpace = AutoSpaceState()
@@ -455,6 +457,16 @@ class EditorInstance(context: Context) : AbstractEditorInstance(context) {
             sendDownUpKeyEvent(KeyEvent.KEYCODE_ENTER)
         } else {
             commitText("\n")
+        }
+    }
+
+    fun tryPerformEnterCommitRaw(): Boolean {
+        return if (subtypeManager.activeSubtype.primaryLocale.language.startsWith("zh") && activeContent.composing.length > 0) {
+            flogDebug { "ENTER: FINALIZECOMPOSINGTEXT ${activeContent.composingText}" }
+            finalizeComposingText(activeContent.composingText)
+        } else {
+            flogDebug { "ENTER: NOTHING" }
+            false
         }
     }
 

--- a/app/src/main/kotlin/dev/patrickgold/florisboard/ime/keyboard/KeyboardManager.kt
+++ b/app/src/main/kotlin/dev/patrickgold/florisboard/ime/keyboard/KeyboardManager.kt
@@ -533,6 +533,20 @@ class KeyboardManager(context: Context) : InputKeyEventReceiver {
     }
 
     /**
+     * Handles a hardware [KeyEvent.KEYCODE_SPACE] event. Same as [handleSpace],
+     * but skips handling changing to characters keyboard and double space periods.
+     */
+    fun handleHardwareKeyboardSpace() {
+        val candidate = nlpManager.getAutoCommitCandidate()
+        candidate?.let { commitCandidate(it) }
+        // Skip handling changing to characters keyboard and double space periods
+        if (subtypeManager.activeSubtype.primaryLocale.isLocaleCJK() &&
+            candidate != null) { /* Do nothing */ } else {
+            editorInstance.commitText(KeyCode.SPACE.toChar().toString())
+        }
+    }
+
+    /**
      * Handles a [KeyCode.SPACE] event. Also handles the auto-correction of two space taps if
      * enabled by the user.
      */
@@ -778,6 +792,21 @@ class KeyboardManager(context: Context) : InputKeyEventReceiver {
             KeyCode.MOVE_START_OF_LINE,
             KeyCode.MOVE_END_OF_LINE -> handleArrow(data.code)
             else -> onInputKeyUp(data)
+        }
+    }
+
+    fun onHardwareKeyDown(keyCode: Int, event: KeyEvent?): Boolean {
+        flogDebug { "ComposeInputView.onKeyDown with $keyCode" }
+        when (keyCode) {
+            KeyEvent.KEYCODE_SPACE -> {
+                handleHardwareKeyboardSpace()
+                return true
+            }
+            KeyEvent.KEYCODE_ENTER -> {
+                handleEnter()
+                return true
+            }
+            else -> return false
         }
     }
 

--- a/app/src/main/kotlin/dev/patrickgold/florisboard/ime/keyboard/KeyboardManager.kt
+++ b/app/src/main/kotlin/dev/patrickgold/florisboard/ime/keyboard/KeyboardManager.kt
@@ -461,6 +461,9 @@ class KeyboardManager(context: Context) : InputKeyEventReceiver {
     private fun handleEnter() {
         val info = editorInstance.activeInfo
         val isShiftPressed = inputEventDispatcher.isPressed(KeyCode.SHIFT)
+        if (editorInstance.tryPerformEnterCommitRaw()) {
+            return
+        }
         if (info.imeOptions.flagNoEnterAction || info.inputAttributes.flagTextMultiLine && isShiftPressed) {
             editorInstance.performEnter()
         } else {

--- a/app/src/main/kotlin/dev/patrickgold/florisboard/ime/keyboard/KeyboardManager.kt
+++ b/app/src/main/kotlin/dev/patrickgold/florisboard/ime/keyboard/KeyboardManager.kt
@@ -35,6 +35,7 @@ import dev.patrickgold.florisboard.ime.ImeUiMode
 import dev.patrickgold.florisboard.ime.core.DisplayLanguageNamesIn
 import dev.patrickgold.florisboard.ime.core.Subtype
 import dev.patrickgold.florisboard.ime.core.SubtypePreset
+import dev.patrickgold.florisboard.ime.editor.EditorContent
 import dev.patrickgold.florisboard.ime.editor.FlorisEditorInfo
 import dev.patrickgold.florisboard.ime.editor.ImeOptions
 import dev.patrickgold.florisboard.ime.editor.InputAttributes
@@ -145,16 +146,13 @@ class KeyboardManager(context: Context) : InputKeyEventReceiver {
         subtypeManager.activeSubtypeFlow.collectLatestIn(scope) {
             reevaluateInputShiftState()
             updateRenderInfo()
+            resetSuggestions(editorInstance.activeContent)
         }
         clipboardManager.primaryClipFlow.collectLatestIn(scope) {
             updateRenderInfo()
         }
         editorInstance.activeContentFlow.collectIn(scope) { content ->
-            if (!activeState.isComposingEnabled) {
-                nlpManager.clearSuggestions()
-                return@collectIn
-            }
-            nlpManager.suggest(subtypeManager.activeSubtype, content)
+            resetSuggestions(content)
         }
     }
 
@@ -237,6 +235,14 @@ class KeyboardManager(context: Context) : InputKeyEventReceiver {
                 else -> InputShiftState.UNSHIFTED
             }
         }
+    }
+
+    fun resetSuggestions(content: EditorContent) {
+        if (!activeState.isComposingEnabled) {
+            nlpManager.clearSuggestions()
+            return
+        }
+        nlpManager.suggest(subtypeManager.activeSubtype, content)
     }
 
     /**

--- a/app/src/main/kotlin/dev/patrickgold/florisboard/ime/nlp/NlpManager.kt
+++ b/app/src/main/kotlin/dev/patrickgold/florisboard/ime/nlp/NlpManager.kt
@@ -17,6 +17,7 @@
 package dev.patrickgold.florisboard.ime.nlp
 
 import android.content.Context
+import android.icu.text.BreakIterator
 import android.os.Build
 import android.os.SystemClock
 import android.util.LruCache
@@ -32,6 +33,7 @@ import dev.patrickgold.florisboard.editorInstance
 import dev.patrickgold.florisboard.ime.clipboard.provider.ItemType
 import dev.patrickgold.florisboard.ime.core.Subtype
 import dev.patrickgold.florisboard.ime.editor.EditorContent
+import dev.patrickgold.florisboard.ime.editor.EditorRange
 import dev.patrickgold.florisboard.ime.nlp.latin.LatinLanguageProvider
 import dev.patrickgold.florisboard.ime.nlp.han.HanShapeBasedLanguageProvider
 import dev.patrickgold.florisboard.keyboardManager
@@ -166,6 +168,12 @@ class NlpManager(context: Context) {
             maxSuggestionCount = maxSuggestionCount,
             allowPossiblyOffensive = !prefs.suggestion.blockPossiblyOffensive.get(),
             isPrivateSession = false,
+        )
+    }
+
+    suspend fun determineLocalComposing(textBeforeSelection: CharSequence, breakIterators: BreakIteratorGroup): EditorRange {
+        return getSuggestionProvider(subtypeManager.activeSubtype).determineLocalComposing(
+            subtypeManager.activeSubtype, textBeforeSelection, breakIterators
         )
     }
 


### PR DESCRIPTION
Two features that improves typing a mixture of Chinese and English.
- Allowing committing raw input using Enter with CJK, and allowing the committed text to persist instead of being included in the composing range again.
- Reset suggestions when changing keyboard subtypes.

Update:
- Let NlpProvider to determine composing range. Latin behavior remains considering the last word, and HanShapeBased only consider lowercase letters.
- Full-width comma for CJK keyboard. Not sure why it's not there.
- Allow minimal handling of physical keyboard input (space and enter). Full-width characters, tab to select candidate etc. are still missing.

~This works now, but many use cases breaks it.~ These works now, but some use cases breaks the composing range preservation (e.g. deleting the composing range forces re-evaluation of composing range). I am not exactly sure if this is the best way to go about it. Maybe I should post this PR in the main repo after your zhengma PR gets merged?

Also, is GitHub the best way to contact you? Let me know if there's anything I can help you finish the zhengma PR.